### PR TITLE
continuum neutrons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- MT=91 continuum (alpha,n) channel support: cross sections and tabulated neutron energy distributions are parsed from GNDS XML files and folded into yield and spectrum calculations
+- Kinematic box fallback for continuum channel when no tabulated neutron energy distribution is available
+
 ## [1.0.1] - 2026-03-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Removed `numba` dependency; replaced `@njit`-decorated loops with vectorized NumPy operations
 - Unified CLI and Python file output around `results.yaml`
 - Removed the duplicate `output.yaml` artifact
+- Removed binned gamma spectrum output (`gamma_spectrum`, `gamma_energy_bins`, `gamma_spectrum_layers`); gamma results now use discrete line pairs only
 - Updated citation with arXiv preprint link ([arXiv:2603.17719](https://arxiv.org/abs/2603.17719))
 
 ## [1.0.0] - 2026-03-11

--- a/alphanso/parsers.py
+++ b/alphanso/parsers.py
@@ -1750,6 +1750,155 @@ def _get_stopping_power_srim(
     return dict(zip(energy_list, stopping_power_list))
 
 
+def _get_continuum_dist_from_reaction(
+        reaction: ET.Element) -> Optional[Dict[float, List[Tuple[float, float]]]]:
+    """
+    Extract the neutron energy distribution from an MT=91 continuum reaction element.
+
+    Handles KalbachMann (<KalbachMann><f><XYs2d>) and direct <XYs2d> formats.
+    Returns None when the distribution element is <unspecified>.
+
+    Args:
+        reaction: ET.Element - MT=91 reaction element from a GNDS XML file
+
+    Returns:
+        {incident_energy_MeV: [(E_out_MeV, prob_1/MeV), ...]}, or None if no tabulated data
+    """
+    product = reaction.find(".//product[@pid='n']")
+    if product is None:
+        return None
+    distribution = product.find("distribution")
+    if distribution is None:
+        return None
+
+    xys2d = None
+    kalbach = distribution.find("KalbachMann")
+    if kalbach is not None:
+        f_elem = kalbach.find("f")
+        if f_elem is not None:
+            xys2d = f_elem.find("XYs2d")
+    else:
+        xys2d = distribution.find("XYs2d")
+
+    if xys2d is None:
+        return None
+
+    func1ds = xys2d.find("function1ds")
+    if func1ds is None:
+        return None
+
+    result = {}
+    for xys1d in func1ds.findall("XYs1d"):
+        e_ev_str = xys1d.get("outerDomainValue")
+        if e_ev_str is None:
+            continue
+        values_elem = xys1d.find("values")
+        if values_elem is None or not values_elem.text:
+            continue
+        raw = [float(x) for x in values_elem.text.split()]
+        if len(raw) < 2 or len(raw) % 2 != 0:
+            continue
+        e_out_arr = raw[::2]
+        prob_arr = raw[1::2]
+        pairs = [(e_out_arr[k] / 1e6, prob_arr[k] * 1e6) for k in range(len(e_out_arr))]
+        result[float(e_ev_str) / 1e6] = pairs
+
+    return result if result else None
+
+
+def get_continuum_info(
+        zaid: int,
+        data_dir: Optional[os.PathLike] = None
+) -> Tuple[Optional[Dict[float, float]], Optional[Dict[float, List[Tuple[float, float]]]]]:
+    """
+    Get cross section and energy distribution for the MT=91 continuum (alpha,n) reaction.
+
+    Reads the MT=91 continuum reaction from the same GNDS XML files used for cross
+    sections. Returns (None, None) when SOURCES data is in use or no MT=91 reaction
+    is present. Returns (continuum_xs, None) when cross section data exists but the
+    neutron energy distribution element is <unspecified>.
+
+    Args:
+        zaid: int - Target nucleus ZAID (ZZZAAA format)
+        data_dir: os.PathLike, optional - Directory containing nuclear data files.
+            Defaults to the standard ENDF data directory.
+
+    Returns:
+        Tuple of (continuum_xs, continuum_dist) where continuum_xs is
+        {energy_MeV: cross_section_barns} and continuum_dist is
+        {incident_energy_MeV: [(E_out_MeV, prob_1/MeV), ...]}.
+        Returns (None, None) if no MT=91 data is found.
+
+    Raises:
+        ValueError: If zaid is not a valid ZZZAAA formatted ZAID
+    """
+    if zaid >= 1e6:
+        raise ValueError(f"ZAID {zaid} is not a valid ZZZAAA formatted ZAID.")
+
+    z = zaid // 1000
+    a = zaid % 1000
+    symbol = atomic_data.get_element_symbol(z)
+
+    if data_dir is None and _should_use_sources_for_an_xs(zaid):
+        return None, None
+
+    if data_dir == "sources" or (
+            data_dir is not None and "sources" in str(data_dir)):
+        return None, None
+
+    if data_dir is None:
+        data_root = _default_data_root()
+        possible_filepaths = [
+            os.path.join(data_root, 'an_xs', "ENDF", _get_endf_filename(zaid)),
+            os.path.join(data_root, 'an_xs', "JENDL", f'{zaid}.xml'),
+            os.path.join(data_root, 'an_xs', "TENDL", f'{zaid}.xml'),
+        ]
+    else:
+        try:
+            data_dir_str = str(data_dir).lower()
+        except (TypeError, AttributeError):
+            data_dir_str = str(data_dir)
+        if "tendl-" in data_dir_str or "tendl" in data_dir_str:
+            possible_filepaths = [
+                os.path.join(data_dir, f"a-{symbol}{a:03d}.tendl.gnds.xml"),
+                os.path.join(data_dir, f"a_{z:03d}-{symbol}-{a:03d}.xml"),
+                os.path.join(data_dir, f"{symbol.upper()}{a:03d}.xml"),
+                os.path.join(data_dir, f"{symbol.capitalize()}{a:03d}.xml"),
+                os.path.join(data_dir, f"{symbol}{a:03d}.xml"),
+                os.path.join(data_dir, f"{zaid}.xml"),
+            ]
+        else:
+            possible_filepaths = [
+                os.path.join(data_dir, f'{zaid}.xml')
+            ]
+
+    found_path = None
+    for cand_path in possible_filepaths:
+        if os.path.exists(cand_path):
+            found_path = cand_path
+            break
+
+    if not found_path:
+        return None, None
+
+    try:
+        tree = ET.parse(found_path)
+        root = tree.getroot()
+    except ET.ParseError:
+        return None, None
+
+    reaction = root.find(".//reaction[@ENDF_MT='91']")
+    if reaction is None:
+        return None, None
+
+    continuum_xs = _get_cross_section_from_reaction(reaction)
+    if continuum_xs is None:
+        return None, None
+
+    continuum_dist = _get_continuum_dist_from_reaction(reaction)
+    return continuum_xs, continuum_dist
+
+
 def _calculate_branching_fractions(
         level_cross_sections: Dict[int, Dict[float, float]]) -> Dict[float, np.ndarray]:
     """

--- a/alphanso/parsers.py
+++ b/alphanso/parsers.py
@@ -181,7 +181,6 @@ def get_an_xs(
     found_path = _find_gnds_xml(zaid, data_dir)
 
     if found_path is None and data_dir is not None:
-        # TENDL directories may use non-standard filenames; fall back to a directory scan.
         try:
             data_dir_str = str(data_dir).lower()
         except (TypeError, AttributeError):
@@ -204,7 +203,6 @@ def get_an_xs(
             except (TypeError, AttributeError):
                 data_dir_str = str(data_dir)
             if "tendl-" not in data_dir_str and "tendl" not in data_dir_str and "endf" not in data_dir_str:
-                # Plain data_dir: attempt parse directly (may raise if missing).
                 return _get_an_xs_xml(os.path.join(data_dir, f"{zaid}.xml"))
         return None
 

--- a/alphanso/transport.py
+++ b/alphanso/transport.py
@@ -11,11 +11,19 @@ from .atomic_data_loader import atomic_data
 from .parsers import (
     get_an_xs,
     get_branching_info,
+    get_continuum_info,
     get_decay_spectrum,
     get_stopping_power,
     get_gamma_cascade_info)
 from .data_manager import ensure_data
-from .utils import rebin_xs, get_composite_stopping, matdef_to_zaids, rebin_endf_spectrum
+from .utils import (
+    rebin_xs,
+    get_composite_stopping,
+    matdef_to_zaids,
+    rebin_endf_spectrum,
+    _accumulate_spectrum_continuum_box,
+    _preprocess_continuum_dist,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -276,7 +284,9 @@ class Transport(object):
             target_mass_amu,
             ep_branching,
             gamma_cascades=None,
-            gamma_energy_bins=None):
+            gamma_energy_bins=None,
+            continuum_xs=None,
+            continuum_dist=None):
         """
         Calculate neutron yield and energy spectrum from alpha slowing down in target.
 
@@ -293,9 +303,15 @@ class Transport(object):
             ep_branching: list - Alpha energy grid for branching ratio interpolation
             gamma_cascades: dict, optional - Gamma cascade data {level_idx: [(final, E_gamma, prob), ...]}
             gamma_energy_bins: ndarray, optional - Energy bins for gamma spectrum
+            continuum_xs: dict, optional - MT=91 continuum cross sections
+                {energy_MeV: cross_section_barns}. If None, no continuum channel is added.
+            continuum_dist: dict, optional - MT=91 neutron energy distribution
+                {incident_energy_MeV: [(E_out_MeV, prob_1/MeV), ...]}. If None and
+                continuum_xs is not None, falls back to a kinematic box over [0, enmax_91].
 
         Returns:
             tuple - (an_yield: float, spectrum: ndarray, gamma_yield: float, gamma_lines: list, gamma_spectrum: ndarray)
+            an_yield includes both discrete and continuum contributions.
         """
 
         nng = len(neutron_energy_bins) - 1
@@ -396,6 +412,18 @@ class Transport(object):
         yield_matrix = prob_steps[:, np.newaxis] * \
             br_matrix * de_valid[:, np.newaxis]
 
+        cont_yield_steps = None
+        if continuum_xs is not None:
+            cont_xs_e = np.array(sorted(continuum_xs.keys()))
+            cont_xs_v = np.array([continuum_xs[e] for e in cont_xs_e])
+            sigma91_cm2 = np.interp(
+                e_steps_valid, cont_xs_e, cont_xs_v, left=0.0, right=0.0) * 1e-24
+            sigma_total_cm2 = cs_cm2_grid[valid_mask]
+            f_91 = np.minimum(sigma91_cm2 / sigma_total_cm2, 1.0)
+            if np.any(f_91 > 0.0):
+                yield_matrix = yield_matrix * (1.0 - f_91[:, np.newaxis])
+                cont_yield_steps = prob_steps * de_valid * f_91
+
         width_matrix = enmax - enmin
         width_matrix[width_matrix <= 0] = 1e-30
 
@@ -420,6 +448,17 @@ class Transport(object):
             overlap = np.maximum(0.0, ov_upper - ov_lower)
 
             spectrum[m] = np.sum(y_flat * overlap / w_flat)
+
+        if cont_yield_steps is not None:
+            if continuum_dist is not None:
+                f_matrix = _preprocess_continuum_dist(
+                    continuum_dist, e_steps_valid, neutron_energy_bins)
+                spectrum = spectrum + np.einsum('i,ij->j', cont_yield_steps, f_matrix)
+            else:
+                spectrum = spectrum + _accumulate_spectrum_continuum_box(
+                    b_lo, b_hi, cont_yield_steps, e_steps_valid,
+                    q_value, product_mass, target_mass_amu,
+                    ANEUT_MASS, ALPH_MASS)
 
         if gamma_cascades is not None and gamma_energy_bins is not None:
             gamma_yield, gamma_lines, gamma_spectrum = Transport._calculate_gamma_spectrum(
@@ -649,6 +688,9 @@ class Transport(object):
                     level_energies=level_energies
                 )
 
+            continuum_xs_data, continuum_dist_data = get_continuum_info(
+                zaid, an_xs_data_source)
+
             target_data_list.append({
                 'zaid': zaid,
                 'afrac': afrac,
@@ -659,7 +701,9 @@ class Transport(object):
                 'level_energies': level_energies,
                 'branching_data': branching_data,
                 'energy_keys': sorted(branching_data.keys()),
-                'gamma_cascades': gamma_cascades
+                'gamma_cascades': gamma_cascades,
+                'continuum_xs': continuum_xs_data,
+                'continuum_dist': continuum_dist_data,
             })
 
         for e_i_pair in energies:
@@ -720,7 +764,9 @@ class Transport(object):
                             t_data['target_mass_amu'],
                             t_data['energy_keys'],
                             gamma_cascades=t_data['gamma_cascades'],
-                            gamma_energy_bins=gamma_energy_bins
+                            gamma_energy_bins=gamma_energy_bins,
+                            continuum_xs=t_data.get('continuum_xs'),
+                            continuum_dist=t_data.get('continuum_dist'),
                         )
                         total_spectrum += spectrum * t_data['afrac'] * i
                         p_total += p * t_data['afrac'] * i
@@ -741,7 +787,9 @@ class Transport(object):
                             t_data['q_value'],
                             t_data['product_mass'],
                             t_data['target_mass_amu'],
-                            t_data['energy_keys']
+                            t_data['energy_keys'],
+                            continuum_xs=t_data.get('continuum_xs'),
+                            continuum_dist=t_data.get('continuum_dist'),
                         )
                         total_spectrum += spectrum * t_data['afrac'] * i
                         p_total += p * t_data['afrac'] * i

--- a/alphanso/utils.py
+++ b/alphanso/utils.py
@@ -2,8 +2,9 @@
 Miscellaneous utility functions for ALPHANSO.
 """
 
+import math
 import numpy as np
-from typing import List, Tuple
+from typing import Dict, List, Optional, Tuple
 from scipy.interpolate import interp1d
 
 from .parsers import get_stopping_power
@@ -213,3 +214,135 @@ def rebin_endf_spectrum(
         spectrum = spectrum / total
 
     return spectrum
+
+
+def _preprocess_continuum_dist(
+        continuum_dist: Optional[Dict[float, List[Tuple[float, float]]]],
+        e_steps_mev: np.ndarray,
+        neutron_bins: np.ndarray) -> np.ndarray:
+    """
+    Pre-process a tabulated continuum energy distribution onto the output energy bin grid.
+
+    For each incident alpha energy step, bi-linearly interpolates f(E_out | E_alpha)
+    between the two bracketing tabulated incident energies and integrates over each
+    output energy bin using the trapezoidal rule.
+
+    Args:
+        continuum_dist: {incident_energy_MeV: [(E_out_MeV, prob_1/MeV), ...]}, or None
+        e_steps_mev: ndarray - Incident alpha energies at each integration step (MeV)
+        neutron_bins: ndarray - Neutron output energy bin edges (MeV)
+
+    Returns:
+        ndarray - Shape (n_steps, n_bins). Each row gives the fraction of continuum
+        yield deposited in each output bin. Rows sum to <= 1.
+    """
+    n_steps = len(e_steps_mev)
+    n_bins = len(neutron_bins) - 1
+    f_matrix = np.zeros((n_steps, n_bins))
+
+    if continuum_dist is None or len(continuum_dist) == 0:
+        return f_matrix
+
+    inc_energies = sorted(continuum_dist.keys())
+    e_min_tab = inc_energies[0]
+
+    b_lo = np.minimum(neutron_bins[:-1], neutron_bins[1:])
+    b_hi = np.maximum(neutron_bins[:-1], neutron_bins[1:])
+
+    for i in range(n_steps):
+        e_alpha = e_steps_mev[i]
+        if e_alpha < e_min_tab:
+            continue
+
+        idx = int(np.searchsorted(inc_energies, e_alpha, side='right')) - 1
+        idx = min(idx, len(inc_energies) - 2)
+
+        e_lo = inc_energies[idx]
+        e_hi_tab = inc_energies[idx + 1]
+        pairs_lo = continuum_dist[e_lo]
+        pairs_hi = continuum_dist[e_hi_tab]
+
+        eo_lo = np.array([p[0] for p in pairs_lo])
+        fp_lo = np.array([p[1] for p in pairs_lo])
+        eo_hi = np.array([p[0] for p in pairs_hi])
+        fp_hi = np.array([p[1] for p in pairs_hi])
+
+        merged_e = np.unique(np.concatenate([eo_lo, eo_hi]))
+        f_lo_interp = np.interp(merged_e, eo_lo, fp_lo, left=0.0, right=0.0)
+        f_hi_interp = np.interp(merged_e, eo_hi, fp_hi, left=0.0, right=0.0)
+
+        t = (e_alpha - e_lo) / (e_hi_tab - e_lo) if e_hi_tab > e_lo else 0.0
+        t = max(0.0, min(t, 1.0))
+        f_blend = f_lo_interp + t * (f_hi_interp - f_lo_interp)
+
+        for m in range(n_bins):
+            e1 = b_lo[m]
+            e2 = b_hi[m]
+            if e2 <= e1:
+                continue
+            inside = merged_e[(merged_e > e1) & (merged_e < e2)]
+            pts = np.concatenate([[e1], inside, [e2]])
+            vals = np.interp(pts, merged_e, f_blend, left=0.0, right=0.0)
+            integral = float(np.trapezoid(vals, pts))
+            if integral > 0.0:
+                f_matrix[i, m] = integral
+
+        row_sum = f_matrix[i].sum()
+        if row_sum > 0.0:
+            f_matrix[i] /= row_sum
+
+    return f_matrix
+
+
+def _accumulate_spectrum_continuum_box(
+        b_lo, b_hi, cont_yield, e_steps,
+        q_value, product_mass, target_mass_amu,
+        aneut_mass, alph_mass):
+    """
+    Accumulate continuum channel spectrum using a kinematic box fallback.
+
+    Used when no tabulated neutron energy distribution is available for MT=91.
+    Distributes each alpha step's yield uniformly over [0, enmax_91] computed
+    from the same two-body kinematic formula as discrete levels with level_energy=0.
+
+    Args:
+        b_lo: ndarray - Lower edges of neutron energy bins (MeV)
+        b_hi: ndarray - Upper edges of neutron energy bins (MeV)
+        cont_yield: ndarray - Continuum yield integrand at each alpha step
+        e_steps: ndarray - Alpha energies at each step (MeV)
+        q_value: float - Ground-state Q-value used as continuum Q approximation (MeV)
+        product_mass: float - Product nucleus mass (amu)
+        target_mass_amu: float - Target nucleus mass (amu)
+        aneut_mass: float - Neutron mass (amu)
+        alph_mass: float - Alpha particle mass (amu)
+
+    Returns:
+        ndarray - Accumulated spectrum, shape (len(b_lo),)
+    """
+    term1 = np.sqrt(alph_mass * aneut_mass * e_steps) / (aneut_mass + product_mass)
+    term2 = (alph_mass * aneut_mass * e_steps) / (aneut_mass + product_mass) ** 2
+    term3 = (product_mass * e_steps + product_mass * q_value -
+             alph_mass * e_steps) / (aneut_mass + product_mass)
+    sqrt_arg = term2 + term3
+
+    valid = (cont_yield > 0.0) & (sqrt_arg >= 0.0)
+    if not np.any(valid):
+        return np.zeros(len(b_lo))
+
+    y_v = cont_yield[valid]
+    sqrt_val_v = np.sqrt(sqrt_arg[valid])
+    enmax_v = (term1[valid] + sqrt_val_v) ** 2
+
+    kinematic_valid = enmax_v > 0.0
+    enmax_v = enmax_v[kinematic_valid]
+    y_v = y_v[kinematic_valid]
+
+    if len(y_v) == 0:
+        return np.zeros(len(b_lo))
+
+    density_v = y_v / enmax_v
+
+    ov_upper = np.minimum(b_hi[:, np.newaxis], enmax_v[np.newaxis, :])
+    ov_lower = b_lo[:, np.newaxis]
+    overlap = np.maximum(0.0, ov_upper - ov_lower)
+    return overlap @ density_v

--- a/alphanso/utils.py
+++ b/alphanso/utils.py
@@ -274,7 +274,6 @@ def _preprocess_continuum_dist(
         t = max(0.0, min(t, 1.0))
         f_blend = f_lo_interp + t * (f_hi_interp - f_lo_interp)
 
-        # Build CDF of f_blend over merged_e, then vectorize bin integration.
         cdf = np.zeros(len(merged_e))
         cdf[1:] = np.cumsum(
             0.5 * (f_blend[:-1] + f_blend[1:]) * np.diff(merged_e)

--- a/tests/integration/test_continuum.py
+++ b/tests/integration/test_continuum.py
@@ -1,0 +1,143 @@
+"""
+Sanity checks for the MT=91 continuum (alpha,n) channel.
+"""
+
+import numpy as np
+import pytest
+from alphanso.parsers import (
+    get_an_xs, get_continuum_info, get_branching_info, get_stopping_power)
+from alphanso.transport import Transport
+from alphanso.utils import rebin_xs
+
+
+EBINS = np.linspace(0, 14, 200)
+
+
+def _integrate(zaid, e_alpha, target_mass, product_mass, cont_xs=None, cont_dist=None):
+    an_xs_b = rebin_xs(get_an_xs(zaid), EBINS)
+    sp_b = rebin_xs(get_stopping_power(zaid), EBINS)
+    q, levels, bdata = get_branching_info(zaid)
+    ep = sorted(bdata.keys())
+    return Transport._integrate_over_ebins(
+        e_alpha, EBINS, an_xs_b, sp_b, bdata, levels,
+        q, product_mass, target_mass, ep,
+        continuum_xs=cont_xs, continuum_dist=cont_dist)
+
+
+class TestContinuumParsing:
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize("zaid", [4009, 8017, 8018])
+    def test_continuum_info_present(self, zaid):
+        """Be-9, O-17, O-18 all have MT=91 in ENDF."""
+        cont_xs, cont_dist = get_continuum_info(zaid)
+        assert cont_xs is not None, f"ZAID {zaid}: expected continuum XS"
+        assert cont_dist is not None, f"ZAID {zaid}: expected continuum distribution"
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize("zaid", [4009, 8017, 8018])
+    def test_continuum_dist_units(self, zaid):
+        """Distribution energies should be in MeV (not eV): incident <20, E_out <20."""
+        _, cont_dist = get_continuum_info(zaid)
+        inc_energies = sorted(cont_dist.keys())
+        assert inc_energies[0] < 20.0, f"ZAID {zaid}: incident energies look like eV not MeV"
+        for pairs in cont_dist.values():
+            e_outs = [p[0] for p in pairs]
+            assert max(e_outs) < 20.0, f"ZAID {zaid}: E_out looks like eV not MeV"
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize("zaid", [4009, 8017, 8018])
+    def test_continuum_dist_normalized(self, zaid):
+        """Each tabulated f(E_out | E_in) should integrate to ~1 over its full range."""
+        _, cont_dist = get_continuum_info(zaid)
+        for e_in, pairs in cont_dist.items():
+            e_outs = np.array([p[0] for p in pairs])
+            probs = np.array([p[1] for p in pairs])
+            integral = float(np.trapezoid(probs, e_outs))
+            assert 0.5 < integral < 2.0, (
+                f"ZAID {zaid} at E_in={e_in:.3f} MeV: integral={integral:.3f}, expected ~1.0")
+
+
+class TestContinuumPhysics:
+
+    @pytest.mark.integration
+    def test_yield_conserved_be9_high_energy(self):
+        """Total yield must be identical with and without continuum (f_91 is a redistribution)."""
+        zaid = 4009
+        cont_xs, cont_dist = get_continuum_info(zaid)
+        r_no = _integrate(zaid, 8.0, 9.0121831, 12.0)
+        r_with = _integrate(zaid, 8.0, 9.0121831, 12.0, cont_xs, cont_dist)
+        assert abs(r_no[0] - r_with[0]) / r_no[0] < 1e-10, (
+            f"Yield changed: {r_no[0]:.6e} -> {r_with[0]:.6e}")
+
+    @pytest.mark.integration
+    def test_yield_conserved_o17_high_energy(self):
+        """Total yield must be identical with and without continuum for O-17."""
+        zaid = 8017
+        cont_xs, cont_dist = get_continuum_info(zaid)
+        r_no = _integrate(zaid, 10.0, 16.9991315, 19.9924402)
+        r_with = _integrate(zaid, 10.0, 16.9991315, 19.9924402, cont_xs, cont_dist)
+        assert abs(r_no[0] - r_with[0]) / r_no[0] < 1e-10, (
+            f"Yield changed: {r_no[0]:.6e} -> {r_with[0]:.6e}")
+
+    @pytest.mark.integration
+    def test_spectral_shift_be9(self):
+        """
+        Above the Be-9 MT=91 threshold, the continuum must shift spectral weight
+        from high-energy bins toward low-energy bins.
+
+        Be-9 at 8 MeV: continuum neutrons peak at 0-1.6 MeV.
+        The low-energy region must gain weight and high-energy must lose.
+        """
+        zaid = 4009
+        cont_xs, cont_dist = get_continuum_info(zaid)
+        r_no = _integrate(zaid, 8.0, 9.0121831, 12.0)
+        r_with = _integrate(zaid, 8.0, 9.0121831, 12.0, cont_xs, cont_dist)
+
+        delta = r_with[1] - r_no[1]
+
+        low_mask = EBINS[:-1] < 2.0
+        high_mask = EBINS[:-1] > 6.0
+
+        assert delta[low_mask].sum() > 0, "Low-energy bins should gain weight from continuum"
+        assert delta[high_mask].sum() < 0, "High-energy bins should lose weight to continuum"
+
+    @pytest.mark.integration
+    def test_spectral_shift_o17(self):
+        """O-17 at 10 MeV: continuum must shift weight toward low-energy bins."""
+        zaid = 8017
+        cont_xs, cont_dist = get_continuum_info(zaid)
+        r_no = _integrate(zaid, 10.0, 16.9991315, 19.9924402)
+        r_with = _integrate(zaid, 10.0, 16.9991315, 19.9924402, cont_xs, cont_dist)
+
+        delta = r_with[1] - r_no[1]
+
+        low_mask = EBINS[:-1] < 3.0
+        high_mask = EBINS[:-1] > 7.0
+
+        assert delta[low_mask].sum() > 0, "Low-energy bins should gain weight from continuum"
+        assert delta[high_mask].sum() < 0, "High-energy bins should lose weight to continuum"
+
+    @pytest.mark.integration
+    def test_no_effect_below_threshold_be9(self):
+        """Below the Be-9 MT=91 threshold (~5.69 MeV), continuum must have zero effect."""
+        zaid = 4009
+        cont_xs, cont_dist = get_continuum_info(zaid)
+        e_below = 5.0
+        r_no = _integrate(zaid, e_below, 9.0121831, 12.0)
+        r_with = _integrate(zaid, e_below, 9.0121831, 12.0, cont_xs, cont_dist)
+
+        assert np.allclose(r_no[1], r_with[1], atol=1e-20), (
+            "Spectrum should be unchanged below the MT=91 threshold")
+
+    @pytest.mark.integration
+    def test_f_matrix_row_sums_be9(self):
+        """f_matrix rows must sum to 1 for steps within the tabulated energy range."""
+        from alphanso.utils import _preprocess_continuum_dist
+        _, cont_dist = get_continuum_info(4009)
+        e_steps = np.array([6.0, 7.0, 8.0, 10.0, 12.0])
+        f_mat = _preprocess_continuum_dist(cont_dist, e_steps, EBINS)
+        for i, e in enumerate(e_steps):
+            row_sum = f_mat[i].sum()
+            assert abs(row_sum - 1.0) < 1e-6, (
+                f"f_matrix row at E={e} MeV sums to {row_sum:.6f}, expected 1.0")


### PR DESCRIPTION
## Description

Adds MT=91 continuum (alpha,n) channel support via an f_91 redistribution approach. Rather than adding a new yield channel (which would double-count, since sigma_91 is already inside MT=201), the discrete-level yield matrix is scaled down by (1 - f_91) at each alpha step and the redistributed fraction is routed through the tabulated f(E_out | E_alpha) from MT=91. Total yield is exactly conserved. Handles KalbachMann and direct XYs2d XML formats; falls back to a kinematic box when the distribution is `<unspecified>`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe below)

## Checklist

- [x] Tests pass locally (`pytest`)
- [x] New tests added (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] PR targets the `main` branch
